### PR TITLE
User Story 3: Separate Pages and Navigation Bar

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -1,0 +1,10 @@
+import Navigation from "./Navigation";
+
+export default function Layout({ children }) {
+  return (
+    <>
+      <Navigation />
+      <main>{children}</main>
+    </>
+  );
+}

--- a/components/Navigation.js
+++ b/components/Navigation.js
@@ -1,0 +1,14 @@
+import Link from "next/link";
+
+export default function Navigation() {
+  return (
+    <nav>
+      <p>
+        <Link href="/spotlight">Spotlight</Link>
+      </p>
+      <p>
+        <Link href="/art-pieces">Pieces</Link>
+      </p>
+    </nav>
+  );
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,10 +1,36 @@
 import GlobalStyle from "../styles";
+import useSWR from "swr";
+import { useEffect, useState } from "react";
+
+const fetcher = (...args) => fetch(...args).then((res) => res.json());
 
 export default function App({ Component, pageProps }) {
+  const { data, error, isLoading } = useSWR(
+    "https://example-apis.vercel.app/api/art",
+    fetcher
+  );
+  const [randomPiece, setRandomPiece] = useState(null);
+
+  useEffect(() => {
+    if (data && data.length > 0) {
+      setRandomPiece(getRandomElement(data));
+    }
+  }, [data]);
+
+  console.log(randomPiece);
+  function getRandomElement(array) {
+    return array[Math.floor(Math.random() * array.length)];
+  }
+
+  if (error) return <div>Failed to load</div>;
+  if (isLoading) return <div>Loading...</div>;
+  console.log(data);
+  console.log(data.name);
+
   return (
     <>
       <GlobalStyle />
-      <Component {...pageProps} />
+      <Component randomPiece={randomPiece} pieces={data} {...pageProps} />
     </>
   );
 }

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,6 +1,7 @@
 import GlobalStyle from "../styles";
 import useSWR from "swr";
 import { useEffect, useState } from "react";
+import Layout from "@/components/Layout";
 
 const fetcher = (...args) => fetch(...args).then((res) => res.json());
 
@@ -29,8 +30,10 @@ export default function App({ Component, pageProps }) {
 
   return (
     <>
-      <GlobalStyle />
-      <Component randomPiece={randomPiece} pieces={data} {...pageProps} />
+      <Layout>
+        <GlobalStyle />
+        <Component randomPiece={randomPiece} pieces={data} {...pageProps} />
+      </Layout>
     </>
   );
 }

--- a/pages/art-pieces/index.js
+++ b/pages/art-pieces/index.js
@@ -1,0 +1,9 @@
+import ArtPieces from "@/components/ArtPieces";
+
+export default function ArtPiecesPage({ pieces }) {
+  return (
+    <div>
+      <ArtPieces pieces={pieces} />
+    </div>
+  );
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,17 +1,5 @@
-import ArtPieces from "@/components/ArtPieces";
 import Spotlight from "@/components/Spotlight";
 
-export default function HomePage({ randomPiece, pieces }) {
-  return (
-    <div>
-      {randomPiece && (
-        <Spotlight
-          image={randomPiece.imageSource}
-          artist={randomPiece.artist}
-        />
-      )}
-
-      <ArtPieces pieces={pieces} />
-    </div>
-  );
+export default function HomePage({}) {
+  return <h1>Welcome to the Art Gallery!</h1>;
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,34 +1,7 @@
-import useSWR from "swr";
 import ArtPieces from "@/components/ArtPieces";
-import { useEffect, useState } from "react";
 import Spotlight from "@/components/Spotlight";
 
-const fetcher = (...args) => fetch(...args).then((res) => res.json());
-
-export default function HomePage() {
-  const { data, error, isLoading } = useSWR(
-    "https://example-apis.vercel.app/api/art",
-    fetcher
-  );
-
-  const [randomPiece, setRandomPiece] = useState(null);
-
-  useEffect(() => {
-    if (data && data.length > 0) {
-      setRandomPiece(getRandomElement(data));
-    }
-  }, [data]);
-
-  console.log(randomPiece);
-
-  function getRandomElement(array) {
-    return array[Math.floor(Math.random() * array.length)];
-  }
-
-  if (error) return <div>Failed to load</div>;
-  if (isLoading) return <div>Loading...</div>;
-  console.log(data);
-  console.log(data.name);
+export default function HomePage({ randomPiece, pieces }) {
   return (
     <div>
       {randomPiece && (
@@ -38,7 +11,7 @@ export default function HomePage() {
         />
       )}
 
-      <ArtPieces pieces={data} />
+      <ArtPieces pieces={pieces} />
     </div>
   );
 }

--- a/pages/spotlight/index.js
+++ b/pages/spotlight/index.js
@@ -1,0 +1,14 @@
+import Spotlight from "@/components/Spotlight";
+
+export default function SpotlightPage({ randomPiece }) {
+  return (
+    <div>
+      {randomPiece && (
+        <Spotlight
+          image={randomPiece.imageSource}
+          artist={randomPiece.artist}
+        />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
**Acceptance Criteria**

 A navigation link labeled "Spotlight" is displayed
 A navigation link labeled "Pieces" is displayed
 Clicking "Spotlight" shows the SpotlightPage
 Clicking "Pieces" shows the ArtPiecesPage
 
**Tasks**

 Move the data fetching logic to pages/_app
 Find a solution for global state handling to have the art pieces available on all pages
 Adapt the page pages/index: rename the function to SpotlightPage and have it render only the Spotlight component
 Create the page pages/art-pieces/index that renders the ArtPieces component
 Create the component Navigation that renders all navigation links
 Create the component Layout that renders the Navigation component
 Apply the Layout component in pages/_app